### PR TITLE
Update hotcss.js

### DIFF
--- a/src/hotcss.js
+++ b/src/hotcss.js
@@ -43,8 +43,8 @@
 
         if( designWidth ){
             document.documentElement.setAttribute('design-width', designWidth);
-            hotcss.designWidth = designWidth;
         }
+        hotcss.designWidth = designWidth; // 保证px2rem 和 rem2px 不传第二个参数时, 获取hotcss.designWidth是undefined导致的NaN
 
         var scale = 1 / dpr,
             content = 'width=device-width, initial-scale=' + scale + ', minimum-scale=' + scale + ', maximum-scale=' + scale + ', user-scalable=no';


### PR DESCRIPTION
保证px2rem 和 rem2px 不传第二个参数时, 获取hotcss.designWidth是undefined导致的NaN的后续问题